### PR TITLE
Fixes error, 'Undefined array key "REQUEST_SCHEME"' in some cases.

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -308,7 +308,7 @@ class Image
     {
         $defaultCurlOptions = [
             CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/116.0',
-            CURLOPT_REFERER => \strtolower($_SERVER["REQUEST_SCHEME"] . '://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]),
+            CURLOPT_REFERER => \strtolower($_SERVER["REQUEST_SCHEME"] ?? 'https' . '://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]),
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_TIMEOUT => 5,
         ];


### PR DESCRIPTION
sets a default referrer to https in cases where the server does not define REQUEST_SCHEME.

determining the scheme reliably can be server-dependent.  If server does not define REQUEST_SCHEME, we get an error, 'Undefined array key "REQUEST_SCHEME"'.

See [[Is $_SERVER['REQUEST_SCHEME'] reliable?](https://stackoverflow.com/questions/18008135/is-serverrequest-scheme-reliable)](https://stackoverflow.com/questions/18008135/is-serverrequest-scheme-reliable) for discussion.